### PR TITLE
doc: Add missing argument to call of build_amis.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Create an AWS profile for your personal account:
 ```
 cd packer/
 librarian-chef install
-./build_amis.sh 1
+./build_amis.sh personal 1
 ```
 
 ## Terraform


### PR DESCRIPTION
Entering the commands

    cd packer
    ./build_amis.sh 1

yields the error message

    Usage: ./build_amis.sh [profile] [build-version]

The script [build_amis.sh](https://github.com/cloudetc/lamp-stack-for-aws/blob/a8a5b66f06defae40eb798280ced290e7e049eec/packer/build_amis.sh#L5) expects two arguments but only one is given in README.md.