### PR TITLE
doc: Set value of profile variable to 'personal'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd terraform/
 terraform init
 terraform get
 terraform apply \
-    -var profile=myprofile \
+    -var profile=personal \
     -var region="us-west-2" 
 ```
 
@@ -50,6 +50,6 @@ Tear down LAMP Stack:
 ```
 cd terraform/
 terraform destroy \
-    -var profile=myprofile \
+    -var profile=personal \
     -var region="us-west-2"
 ```


### PR DESCRIPTION
The commands

    $ cd terraform
    $ terraform apply -var profile=myprofile -var region=us-west-2

yield the error message

    Error: Error refreshing state: 1 error(s) occurred:
    
    * provider.aws: NoCredentialProviders: no valid providers in chain. Deprecated.
	    For verbose messaging see aws.Config.CredentialsChainVerboseErrors

After replacing `myprofile` with `personal` executing terraform works.